### PR TITLE
Add stepwise brightness control

### DIFF
--- a/data/index.htm
+++ b/data/index.htm
@@ -45,6 +45,14 @@
           <div class="input-group">
             <span class="input-group-addon" id="spanBrightness">128</span>
             <input class="form-control" id="inputBrightness" type="range" step="1" min="0" max="255" />
+            <div class="input-group-btn">
+              <button type="button" class="btn btn-default" id="btnBrightnessDown">
+                <span class="glyphicon glyphicon-minus" aria-hidden="true"></span>
+              </button>
+              <button type="button" class="btn btn-default" id="btnBrightnessUp">
+                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/data/js/scripts.js
+++ b/data/js/scripts.js
@@ -66,6 +66,14 @@ $("#inputBrightness").on("change", function() {
    delaySetBrightness();
 });
 
+$("#btnBrightnessDown").click( function() {
+  stepBrightness(false);
+});
+
+$("#btnBrightnessUp").click( function() {
+  stepBrightness(true);
+});
+
 $("#inputPattern").change(function() {
    setPattern($("#inputPattern option:selected").index());
 });
@@ -164,6 +172,15 @@ function delaySetBrightness() {
 function setBrightness(value) {
   $.post(urlBase + "brightness?value=" + value, function(data) {
     $("#status").html("Set Brightness: " + data);
+  });
+}
+
+function stepBrightness(up) {
+  $.post(urlBase + (up ? "brightnessUp" : "brightnessDown"), function(data) {
+    data = JSON.parse(data);
+    $("#status").html("Set Brightness: " + data);
+    $("#spanBrightness").html(data);
+    $("#inputBrightness").val(data);
   });
 }
 

--- a/esp8266-fastled-webserver.ino
+++ b/esp8266-fastled-webserver.ino
@@ -57,11 +57,7 @@ ESP8266WebServer server(80);
 CRGB leds[NUM_LEDS];
 
 uint8_t patternIndex = 0;
-
-const uint8_t brightnessCount = 5;
-uint8_t brightnessMap[brightnessCount] = { 16, 32, 64, 128, 255 };
-int brightnessIndex = 0;
-uint8_t brightness = brightnessMap[brightnessIndex];
+uint8_t brightness = 16;
 
 #define ARRAY_SIZE(A) (sizeof(A) / sizeof((A)[0]))
 
@@ -774,18 +770,14 @@ void setPalette(int value)
 // adjust the brightness, and wrap around at the ends
 void adjustBrightness(bool up)
 {
-  if (up)
-    brightnessIndex++;
-  else
-    brightnessIndex--;
-
-  // wrap around at the ends
-  if (brightnessIndex < 0)
-    brightnessIndex = brightnessCount - 1;
-  else if (brightnessIndex >= brightnessCount)
-    brightnessIndex = 0;
-
-  brightness = brightnessMap[brightnessIndex];
+  if (up) {
+    if (brightness > 254) brightness = 0;
+    else brightness++;
+  }
+  else {
+    if (brightness < 1) brightness = 255;
+    else brightness--;
+  }
 
   FastLED.setBrightness(brightness);
 


### PR DESCRIPTION
I just found this old change and thought I could be useful for others too. 

My LEDs were really bright, so I needed more precise brightness control.
I added plus and minus buttons in the UI and change brightnessUp/Down API to stepwise control.
I also removed the brightness map. Don't know, if it is required somehow...

![screenshot_20171111-212656](https://user-images.githubusercontent.com/1899308/32692796-68b64ef6-c727-11e7-88c0-33f06a6b1c22.png)
