### PR TITLE
Updated index.htm to disable scaling bug

### DIFF
--- a/data/index.htm
+++ b/data/index.htm
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
   <title>ESP8266 + FastLED by Evil Genius Labs</title>
 
   <!-- request CSS from internet CDN -->


### PR DESCRIPTION
On mobile views Select menus would cause window resizing, which would lead to content cut off of the page. Disabled scaling so the page would behave more like a native app.