### PR TITLE
Fixed bootloop when using longer LED strips with some effects

### DIFF
--- a/esp8266-fastled-webserver.ino
+++ b/esp8266-fastled-webserver.ino
@@ -1117,10 +1117,10 @@ void heatMap(CRGBPalette16 palette, bool up)
   fill_solid(leds, NUM_LEDS, CRGB::Black);
 
   // Add entropy to random number generator; we use a lot of it.
-  random16_add_entropy(random(256));
+  random16_add_entropy(random(NUM_LEDS));
 
   // Array of temperature readings at each simulation cell
-  static byte heat[256];
+  static byte heat[NUM_LEDS];
 
   byte colorindex;
 


### PR DESCRIPTION
Fixed bootloop when using longer LED strips with some effects. Hardcoded LED count in "heatMap" function caused an exception which leads to ESP8266 reboot when using LED strips which are longer than 256 LEDs. This exception was caused by effects "Water" and "Fire". Additionaly, when this effect index were written to EEPROM, device will enter permament bootloop which can be fixed only by erasing EEPROM.