### PR TITLE
add a sample config file to store preferences and crendentials, Issue #124

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.h

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 config.h
+.vscode/

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ With ESP8266FS installed upload the web app using `ESP8266 Sketch Data Upload` c
 
 Copy the config.h.sample file to config.h
 
-Then enter your wi-fi network SSID and password in the config.h file, adjust some parameter as the number of LEDs in your Strip, and upload the sketch using the Upload button.
+Then enter your wi-fi network SSID and password in the config.h file or the wifi AP name and password if you prefer a standalone wifi network, adjust some parameters as the number of LEDs in your Strip, and upload the sketch using the Upload button.
 
 Compression
 -----------

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ The web app needs to be uploaded to the ESP8266's SPIFFS.  You can do this withi
 
 With ESP8266FS installed upload the web app using `ESP8266 Sketch Data Upload` command in the Arduino Tools menu.
 
-Then enter your wi-fi network SSID and password in the WiFi.h file, and upload the sketch using the Upload button.
+Copy the config.h.sample file to config.h
+
+Then enter your wi-fi network SSID and password in the config.h file, adjust some parameter as the number of LEDs in your Strip, and upload the sketch using the Upload button.
 
 Compression
 -----------

--- a/config.h.sample
+++ b/config.h.sample
@@ -1,0 +1,22 @@
+//--------------------------------------------------------------------------------
+// WIFI configuration
+//--------------------------------------------------------------------------------
+// AP mode password
+const char WiFiAPPSK[] = "";
+
+// Wi-Fi network to connect to (if not in AP mode)
+char* ssid = "";
+char* password = "";
+
+const bool apMode = false; // Whether if ESP8266 should connect to an existing WIFI or mount its own AP
+
+//--------------------------------------------------------------------------------
+// LEDs Strip configuration
+//--------------------------------------------------------------------------------
+#define DATA_PIN      D5
+#define LED_TYPE      WS2811
+#define COLOR_ORDER   RGB
+#define NUM_LEDS      200
+
+#define MILLI_AMPS         2000 // IMPORTANT: set the max milli-Amps of your power supply (4A = 4000mA)
+#define FRAMES_PER_SECOND  120  // here you can control the speed. With the Access Point / Web Server the animations run a bit slower.

--- a/config.h.sample
+++ b/config.h.sample
@@ -1,8 +1,13 @@
 //--------------------------------------------------------------------------------
 // WIFI configuration
 //--------------------------------------------------------------------------------
-// AP mode password
+// AP mode name and password
+const char WiFiAPName[] = "LightControlAP";
 const char WiFiAPPSK[] = "";
+
+// IP configuration for AP
+IPAddress WiFiIp(192, 168, 10, 1);
+IPAddress WiFiNMask(255, 255, 255, 0);
 
 // Wi-Fi network to connect to (if not in AP mode)
 char* ssid = "";

--- a/esp8266-fastled-webserver.ino
+++ b/esp8266-fastled-webserver.ino
@@ -37,6 +37,8 @@ extern "C" {
 //#include <IRremoteESP8266.h>
 #include "GradientPalettes.h"
 
+#include "config.h" // this file is intentionally not included in the sketch, so nobody accidentally commits their secret information or thier own parameter values. Please copy config.h.sample to config.h 
+
 #define ARRAY_SIZE(A) (sizeof(A) / sizeof((A)[0]))
 
 #include "Field.h"
@@ -51,27 +53,6 @@ ESP8266WebServer webServer(80);
 ESP8266HTTPUpdateServer httpUpdateServer;
 
 #include "FSBrowser.h"
-
-#define DATA_PIN      D5
-#define LED_TYPE      WS2811
-#define COLOR_ORDER   RGB
-#define NUM_LEDS      200
-
-#define MILLI_AMPS         2000 // IMPORTANT: set the max milli-Amps of your power supply (4A = 4000mA)
-#define FRAMES_PER_SECOND  120  // here you can control the speed. With the Access Point / Web Server the animations run a bit slower.
-
-const bool apMode = false;
-
-#include "Secrets.h" // this file is intentionally not included in the sketch, so nobody accidentally commits their secret information.
-// create a Secrets.h file with the following:
-
-// AP mode password
-// const char WiFiAPPSK[] = "your-password";
-
-// Wi-Fi network to connect to (if not in AP mode)
-// char* ssid = "your-ssid";
-// char* password = "your-password";
-
 
 CRGB leds[NUM_LEDS];
 

--- a/esp8266-fastled-webserver.ino
+++ b/esp8266-fastled-webserver.ino
@@ -249,26 +249,15 @@ void setup() {
   if (apMode)
   {
     WiFi.mode(WIFI_AP);
+    // Set IP and mask for AP
+    WiFi.softAPConfig(WiFiIp, WiFiIp, WiFiNMask);
+    WiFi.softAP(WiFiAPName, WiFiAPPSK);
+    IPAddress apIP = WiFi.softAPIP();
 
-    // Do a little work to get a unique-ish name. Append the
-    // last two bytes of the MAC (HEX'd) to "Thing-":
-    uint8_t mac[WL_MAC_ADDR_LENGTH];
-    WiFi.softAPmacAddress(mac);
-    String macID = String(mac[WL_MAC_ADDR_LENGTH - 2], HEX) +
-                   String(mac[WL_MAC_ADDR_LENGTH - 1], HEX);
-    macID.toUpperCase();
-    String AP_NameString = "ESP8266 Thing " + macID;
-
-    char AP_NameChar[AP_NameString.length() + 1];
-    memset(AP_NameChar, 0, AP_NameString.length() + 1);
-
-    for (int i = 0; i < AP_NameString.length(); i++)
-      AP_NameChar[i] = AP_NameString.charAt(i);
-
-    WiFi.softAP(AP_NameChar, WiFiAPPSK);
-
-    Serial.printf("Connect to Wi-Fi access point: %s\n", AP_NameChar);
-    Serial.println("and open http://192.168.4.1 in your browser");
+    Serial.printf("Connect to Wi-Fi access point: %s\n", WiFiAPName);
+    Serial.print("and open http://"); 
+    Serial.print(apIP); 
+    Serial.println(" in your browser");
   }
   else
   {


### PR DESCRIPTION
The sample config file has to be copied to config.h, to store LEDs preferences and wifi credentials. 
The `config.h` file is intentionally not in the repo, but the `config.h.sample` file is.