### PR TITLE
Enable PlatformIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@ build/
 buildcache/
 arduino.json
 c_cpp_properties.json
-.vscode
 
-/platformio-override.ini
-/release/
+/.vscode/
+/release
+/platformio_override.ini
+/.pio/
+/esp8266-fastled-webserver/esp8266-fastled-webserver.ino.cpp

--- a/esp8266-fastled-webserver/common.h
+++ b/esp8266-fastled-webserver/common.h
@@ -31,10 +31,6 @@
   #include <FastLED.h>
   FASTLED_USING_NAMESPACE
 
-  extern "C" {
-  #include "user_interface.h"
-  }
-
   #include <LittleFS.h>
   #define MYFS LittleFS
 

--- a/esp8266-fastled-webserver/config.h
+++ b/esp8266-fastled-webserver/config.h
@@ -24,18 +24,21 @@
 // When compiling from Arduino, you can edit this file.
 // When compiling from PlatformIO, this is a reference for compiler flags.
 
-#define PRODUCT_DEFAULT
-// #define PRODUCT_FIBONACCI512
-// #define PRODUCT_FIBONACCI256
-// #define PRODUCT_FIBONACCI128
-// #define PRODUCT_FIBONACCI64_FULL  // 86mm, WS2812B-5050, ~60mA/pixel
-// #define PRODUCT_FIBONACCI64_MINI  // 64mm, WS2812B-3535, ~60mA/pixel
-// #define PRODUCT_FIBONACCI64_MICRO // 40mm, WS2812C-2020,  ~5mA/pixel
-// #define PRODUCT_FIBONACCI64_NANO  // 33mm, SK6805-EC15,   ~5mA/pixel
-// #define PRODUCT_FIBONACCI32
-// #define PRODUCT_KRAKEN64
-// #define PRODUCT_ESP8266_THING // aka parallel (6-output)
-// #define PRODUCT_1628_RINGS
+#if !defined(BUILDING_USING_PLATFORMIO)
+    #define PRODUCT_DEFAULT
+    // #define PRODUCT_FIBONACCI512
+    // #define PRODUCT_FIBONACCI256
+    // #define PRODUCT_FIBONACCI128
+    // #define PRODUCT_FIBONACCI64_FULL  // 86mm, WS2812B-5050, ~60mA/pixel
+    // #define PRODUCT_FIBONACCI64_MINI  // 64mm, WS2812B-3535, ~60mA/pixel
+    // #define PRODUCT_FIBONACCI64_MICRO // 40mm, WS2812C-2020,  ~5mA/pixel
+    // #define PRODUCT_FIBONACCI64_NANO  // 33mm, SK6805-EC15,   ~5mA/pixel
+    // #define PRODUCT_FIBONACCI32
+    // #define PRODUCT_KRAKEN64
+    // #define PRODUCT_ESP8266_THING // aka parallel (6-output)
+    // #define PRODUCT_1628_RINGS
+#endif /// !defined(BUILDING_USING_PLATFORMIO)
+
 
 // ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Additional configuration options ... defaults shown

--- a/esp8266-fastled-webserver/esp8266-fastled-webserver.ino
+++ b/esp8266-fastled-webserver/esp8266-fastled-webserver.ino
@@ -110,6 +110,9 @@ const PatternAndName patterns[] = {
 #endif
 
   { colorWaves,             "Color Waves" },
+#if IS_FIBONACCI
+  { colorWavesFibonacci,               "Color Waves Fibonacci" },
+#endif
 
 #if HAS_COORDINATE_MAP // really a wrong name... and likely doing way more computation than necessary
   { radarSweepPalette, "Radar Sweep Palette" },
@@ -132,8 +135,6 @@ const PatternAndName patterns[] = {
 #endif
 
 #if IS_FIBONACCI
-  { colorWavesFibonacci,               "Color Waves Fibonacci" },
-
   { pridePlayground,                   "Pride Playground" },
   { pridePlaygroundFibonacci,          "Pride Playground Fibonacci" },
 

--- a/include/README
+++ b/include/README
@@ -1,0 +1,39 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the usual convention is to give header files names that end with `.h'.
+It is most portable to use only letters, digits, dashes, and underscores in
+header file names, and at most one dot.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/lib/README
+++ b/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into executable file.
+
+The source code of each library should be placed in a an own separate directory
+("lib/your_library_name/[here are source files]").
+
+For example, see a structure of the following two libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+and a contents of `src/main.c`:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+PlatformIO Library Dependency Finder will find automatically dependent
+libraries scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/pio-scripts/obj-dump.py
+++ b/pio-scripts/obj-dump.py
@@ -1,0 +1,9 @@
+# Little convenience script to get an object dump
+
+Import('env')
+
+def obj_dump_after_elf(source, target, env):
+    print("Create firmware.asm")
+    env.Execute("xtensa-lx106-elf-objdump "+ "-D " + str(target[0]) + " > "+ "${PROGNAME}.asm")
+    
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.elf", [obj_dump_after_elf])

--- a/pio-scripts/strip-floats.py
+++ b/pio-scripts/strip-floats.py
@@ -1,0 +1,15 @@
+Import('env')
+
+#
+# Dump build environment (for debug)
+#print env.Dump()
+#
+
+flags = " ".join(env['LINKFLAGS'])
+flags = flags.replace("-u _printf_float", "")
+flags = flags.replace("-u _scanf_float", "")
+newflags = flags.split()
+
+env.Replace(
+  LINKFLAGS=newflags
+)

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,8 +30,6 @@ default_envs = fastled_webserver, fib512_d1_mini, fib256_d1_mini, fib128_d1_mini
 src_dir = ./esp8266-fastled-webserver/
 data_dir = ./esp8266-fastled-webserver/data
 build_cache_dir = ~/.buildcache
-; Uncomment the below to switch from deprecated SPIFFS to LittleFS
-; board_build.filesystem = littlefs
 
 [common]
 ldscript_1m128k = eagle.flash.1m128.ld
@@ -85,6 +83,7 @@ extra_scripts =
 [env]
 framework = arduino
 board_build.flash_mode = dout
+board_build.filesystem = littlefs
 monitor_speed = 115200
 upload_speed = 921600
 lib_compat_mode = strict
@@ -177,13 +176,12 @@ build_flags =
 
 
 ; NOT YET SUPPORTED.
-; Default board is QT Py, a ATSAMD21E18
-; - 32-bit Cortex M0+ @ 48 MHz 32 bit
-;   w/256KB Flash and 32 KB RAM
+; QT Py does not have WiFi.
+; QT Py is a ATSAMD21E18 32-bit Cortex M0+
+; - 48 MHz 32 bit processor with
+;   256KB Flash and 32 KB RAM
 ; Support *is* possible, but would require
 ; factoring out all the WiFi functionality (at least).
-; However, may be able to enable building
-; using ESP8266/ESP32 more rapidly....
 [env:fib64_micro_d1_mini]
 board = d1_mini
 platform = ${common.platform_fibonacci_default}
@@ -195,13 +193,12 @@ build_flags =
 	-D PRODUCT_FIBONACCI64_MICRO
 
 ; NOT YET SUPPORTED.
-; Default board is QT Py, a ATSAMD21E18
-; - 32-bit Cortex M0+ @ 48 MHz 32 bit
-;   w/256KB Flash and 32 KB RAM
+; QT Py does not have WiFi.
+; QT Py is a ATSAMD21E18 32-bit Cortex M0+
+; - 48 MHz 32 bit processor with
+;   256KB Flash and 32 KB RAM
 ; Support *is* possible, but would require
 ; factoring out all the WiFi functionality (at least).
-; However, may be able to enable building
-; using ESP8266/ESP32 more rapidly....
 [env:fib64_nano_d1_mini]
 board = d1_mini
 platform = ${common.platform_fibonacci_default}
@@ -222,20 +219,14 @@ build_flags =
 	${common.build_flags_esp8266}
 	-D PRODUCT_FIBONACCI32
 
-; [env:fib256_d1_mini32]
-; board = esp32dev
-; platform = espressif32@2.0
-; build_unflags = ${common.build_unflags}
-; build_flags = ${common.build_flags_esp32}
-
-; [env:travis_esp8266]
-; extends = env:fib256_d1_mini
-; build_type = debug
-; build_unflags = ${common.build_unflags}
-; build_flags = ${common.build_flags_esp8266} ${common.debug_flags} ${common.build_flags_all_features}
-
-; [env:travis_esp32]
-; extends = env:fib256_d1_mini32
-; build_type = debug
-; build_unflags = ${common.build_unflags}
-; build_flags = ${common.build_flags_esp32} ${common.debug_flags} ${common.build_flags_all_features}
+; NOT YET SUPPORTED
+; ESP32 is a work-in-progress
+[env:fib256_d1_mini32]
+board = wemos_d1_mini32
+platform = espressif32@2.0
+platform_packages = ${common.platform_packages}
+board_build.ldscript = ${common.ldscript_4m1m}
+build_unflags = ${common.build_unflags}
+build_flags =
+	${common.build_flags_esp32}
+	-D PRODUCT_FIBONACCI256

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,241 @@
+; NOTE:
+; If "file system upload" command is missing PlatformIO UI in VSCode:
+; run `pio run -t uploadfs` in the terminal.
+; Typically, this is caused by having an invalid platformio.ini
+; (or platform_override.ini), and this will show a more coherent
+; error message in the terminal output.
+
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+extra_configs = platformio_override.ini ; so users can easily override settings
+default_envs = fastled_webserver, fib512_d1_mini, fib256_d1_mini, fib128_d1_mini, fib64_full_d1_mini, fib64_mini_d1_mini, fib32_d1_mini
+; default_envs = fastled_webserver
+; default_envs = fib512_d1_mini
+; default_envs = fib256_d1_mini
+; default_envs = fib128_d1_mini
+; default_envs = fib64_full_d1_mini
+; default_envs = fib64_mini_d1_mini
+; default_envs = fib64_micro_d1_mini
+; default_envs = fib64_nano_d1_mini
+; default_envs = fib32_d1_mini
+src_dir = ./esp8266-fastled-webserver/
+data_dir = ./esp8266-fastled-webserver/data
+build_cache_dir = ~/.buildcache
+; Uncomment the below to switch from deprecated SPIFFS to LittleFS
+; board_build.filesystem = littlefs
+
+[common]
+ldscript_1m128k = eagle.flash.1m128.ld
+ldscript_2m512k = eagle.flash.2m512.ld
+ldscript_2m1m = eagle.flash.2m1m.ld
+ldscript_4m1m = eagle.flash.4m1m.ld
+debug_flags = 
+	-D DEBUG=1
+	-D DEBUG_ESP_PORT=Serial
+build_flags = 
+	-Wall
+	-Wextra
+	-fno-exceptions
+	-D SECURE_CLIENT=SECURE_CLIENT_BEARSSL
+	-D NDEBUG
+	-D BUILDING_USING_PLATFORMIO
+
+build_flags_esp8266 = ${common.build_flags}  ${esp8266.build_flags}
+build_flags_esp32 = ${common.build_flags}  ${esp32.build_flags}
+build_unflags = 
+
+; YES, the mismatch in version numbers is confusing.
+; This gives the *LATEST* espressif release for a given arduino core version.
+arduino_core_2_6_3   = espressif8266@2.4.0
+arduino_core_2_7_0   = espressif8266@2.5.0
+arduino_core_2_7_1   = espressif8266@2.5.3
+arduino_core_2_7_2   = espressif8266@2.6.0
+arduino_core_2_7_3   = espressif8266@2.6.1
+arduino_core_2_7_4   = espressif8266@2.6.3
+; WARNING -- Moving to v3.0.0 or higher risks MAJOR breaking changes.
+;            See https://github.com/esp8266/Arduino/releases/tag/3.0.0
+;            In particular, new() no longer will return nullptr ...
+;            See https://github.com/esp8266/Arduino/pull/7536#issuecomment-683431735
+arduino_core_3_0_0   = espressif8266@3.0.0
+arduino_core_3_0_1   = espressif8266@3.1.0
+arduino_core_3_0_2   = espressif8266@3.2.0
+arduino_core_develop = https://github.com/platformio/platform-espressif8266#develop
+arduino_core_git = https://github.com/platformio/platform-espressif8266#feature/stage
+
+; Define the version to use based on the Arduino Core version...
+platform_fibonacci_default = ${common.arduino_core_2_7_4}
+platform_packages = tasmota/framework-arduinoespressif8266 @ 3.20704.7
+	platformio/toolchain-xtensa @ ~2.40802.200502
+	platformio/tool-esptool @ ~1.413.0
+	platformio/tool-esptoolpy @ ~1.30000.0
+
+[scripts_defaults]
+extra_scripts = 
+	post:pio-scripts/strip-floats.py
+
+[env]
+framework = arduino
+board_build.flash_mode = dout
+monitor_speed = 115200
+upload_speed = 921600
+lib_compat_mode = strict
+lib_deps = 
+	fastled/FastLED              @ 3.4.0
+	https://github.com/arduino-libraries/NTPClient.git @ 3.2.0
+	https://github.com/tzapu/WiFiManager.git @ ^2.0.4-beta
+
+extra_scripts = ${scripts_defaults.extra_scripts}
+
+[esp8266]
+build_flags = 
+	-D ESP8266
+	-D FP_IN_IROM
+	-D PIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
+	-D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+	-D VTABLES_IN_FLASH
+	-D MIMETYPE_MINIMAL
+lib_deps = 
+	${env.lib_deps}
+
+[esp32]
+build_flags = 
+	-g
+	-D ARDUINO_ARCH_ESP32
+	-D CONFIG_LITTLEFS_FOR_IDF_3_2
+lib_deps = 
+	${env.lib_deps}
+
+[env:fastled_webserver]
+board = d1_mini
+platform = ${common.platform_fibonacci_default}
+platform_packages = ${common.platform_packages}
+board_build.ldscript = ${common.ldscript_4m1m}
+build_unflags = ${common.build_unflags}
+build_flags =
+	${common.build_flags_esp8266}
+	-D PRODUCT_DEFAULT
+
+[env:fib512_d1_mini]
+board = d1_mini
+platform = ${common.platform_fibonacci_default}
+platform_packages = ${common.platform_packages}
+board_build.ldscript = ${common.ldscript_4m1m}
+build_unflags = ${common.build_unflags}
+build_flags =
+	${common.build_flags_esp8266}
+	-D PRODUCT_FIBONACCI512
+
+[env:fib256_d1_mini]
+board = d1_mini
+platform = ${common.platform_fibonacci_default}
+platform_packages = ${common.platform_packages}
+board_build.ldscript = ${common.ldscript_4m1m}
+build_unflags = ${common.build_unflags}
+build_flags =
+	${common.build_flags_esp8266}
+	-D PRODUCT_FIBONACCI256
+
+[env:fib128_d1_mini]
+board = d1_mini
+platform = ${common.platform_fibonacci_default}
+platform_packages = ${common.platform_packages}
+board_build.ldscript = ${common.ldscript_4m1m}
+build_unflags = ${common.build_unflags}
+build_flags =
+	${common.build_flags_esp8266}
+	-D PRODUCT_FIBONACCI128
+
+[env:fib64_full_d1_mini]
+board = d1_mini
+platform = ${common.platform_fibonacci_default}
+platform_packages = ${common.platform_packages}
+board_build.ldscript = ${common.ldscript_4m1m}
+build_unflags = ${common.build_unflags}
+build_flags =
+	${common.build_flags_esp8266}
+	-D PRODUCT_FIBONACCI64_FULL
+
+
+[env:fib64_mini_d1_mini]
+board = d1_mini
+platform = ${common.platform_fibonacci_default}
+platform_packages = ${common.platform_packages}
+board_build.ldscript = ${common.ldscript_4m1m}
+build_unflags = ${common.build_unflags}
+build_flags =
+	${common.build_flags_esp8266}
+	-D PRODUCT_FIBONACCI64_MINI
+
+
+; NOT YET SUPPORTED.
+; Default board is QT Py, a ATSAMD21E18
+; - 32-bit Cortex M0+ @ 48 MHz 32 bit
+;   w/256KB Flash and 32 KB RAM
+; Support *is* possible, but would require
+; factoring out all the WiFi functionality (at least).
+; However, may be able to enable building
+; using ESP8266/ESP32 more rapidly....
+[env:fib64_micro_d1_mini]
+board = d1_mini
+platform = ${common.platform_fibonacci_default}
+platform_packages = ${common.platform_packages}
+board_build.ldscript = ${common.ldscript_4m1m}
+build_unflags = ${common.build_unflags}
+build_flags =
+	${common.build_flags_esp8266}
+	-D PRODUCT_FIBONACCI64_MICRO
+
+; NOT YET SUPPORTED.
+; Default board is QT Py, a ATSAMD21E18
+; - 32-bit Cortex M0+ @ 48 MHz 32 bit
+;   w/256KB Flash and 32 KB RAM
+; Support *is* possible, but would require
+; factoring out all the WiFi functionality (at least).
+; However, may be able to enable building
+; using ESP8266/ESP32 more rapidly....
+[env:fib64_nano_d1_mini]
+board = d1_mini
+platform = ${common.platform_fibonacci_default}
+platform_packages = ${common.platform_packages}
+board_build.ldscript = ${common.ldscript_4m1m}
+build_unflags = ${common.build_unflags}
+build_flags =
+	${common.build_flags_esp8266}
+	-D PRODUCT_FIBONACCI64_NANO
+
+[env:fib32_d1_mini]
+board = d1_mini
+platform = ${common.platform_fibonacci_default}
+platform_packages = ${common.platform_packages}
+board_build.ldscript = ${common.ldscript_4m1m}
+build_unflags = ${common.build_unflags}
+build_flags =
+	${common.build_flags_esp8266}
+	-D PRODUCT_FIBONACCI32
+
+; [env:fib256_d1_mini32]
+; board = esp32dev
+; platform = espressif32@2.0
+; build_unflags = ${common.build_unflags}
+; build_flags = ${common.build_flags_esp32}
+
+; [env:travis_esp8266]
+; extends = env:fib256_d1_mini
+; build_type = debug
+; build_unflags = ${common.build_unflags}
+; build_flags = ${common.build_flags_esp8266} ${common.debug_flags} ${common.build_flags_all_features}
+
+; [env:travis_esp32]
+; extends = env:fib256_d1_mini32
+; build_type = debug
+; build_unflags = ${common.build_unflags}
+; build_flags = ${common.build_flags_esp32} ${common.debug_flags} ${common.build_flags_all_features}

--- a/test/README
+++ b/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Unit Testing and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/page/plus/unit-testing.html


### PR DESCRIPTION
* Compilation succeeds for all seven expected products
* Tested on Fibonacci256 board
* Compilation fails as expected for two products not
  yet supported (fib64 micro and nano)
* Intellisense updates correctly when changing between
   products.  To see in action, open map.cpp, then:
   CTRL-SHIFT-P, PlatformIO:  switch project environment
   Select the new environment, and then wait for the
   intellisense index to be rebuilt.
* Fixed to properly generate LittleFS (not SPIFFS)

