### PR TITLE
Enable first level of PIO "inspect" aka static analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,12 @@ buildcache/
 arduino.json
 c_cpp_properties.json
 
+cppcheck-addon-ctu-file-list
+*.ctu-info
+*.dump
+
 /.vscode/
+/.vs
 /release
 /platformio_override.ini
 /.pio/

--- a/platformio.ini
+++ b/platformio.ini
@@ -39,7 +39,7 @@ default_envs = fastled_webserver__d1_mini, fib512__d1_mini, fib256__d1_mini, fib
 
 src_dir = ./esp8266-fastled-webserver/
 data_dir = ./esp8266-fastled-webserver/data
-build_cache_dir = ~/.buildcache
+; build_cache_dir = ~/.buildcache
 
 [common]
 ldscript_1m128k = eagle.flash.1m128.ld
@@ -91,6 +91,13 @@ extra_scripts =
 	post:pio-scripts/strip-floats.py
 
 [env]
+check_skip_packages = yes           # required for cppcheck to not crash as of 2021-12-14
+check_tool = cppcheck
+# check_tool = cppcheck, clangtidy  # eventually want to also run clangtidy (which crashes with error 0xC0000005 (STATUS_ACCESS_VIOLATION))
+check_flags =
+	cppcheck: --enable=all --std=c++11 --inconclusive --addon=cert.py
+	clangtidy: --checks=*
+
 framework = arduino
 board_build.flash_mode = dout
 board_build.filesystem = littlefs


### PR DESCRIPTION
cppcheck crashes on many Arduino platforms, incl. ESP8266.

The workaround is included here:

`check_skip_packages = yes`

Also add temp analysis files to .gitignore