### PR TITLE
Store build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,15 +6,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        
+
       - name: Build with Arduino-CLI
         run: bash ci/build-arduino.sh
-        
+
   pio-build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        
+
       - name: Build with PlatformIO
         run: bash ci/build-platformio.sh
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: firmware
+          path: .pio/build/*/firmware.bin


### PR DESCRIPTION
This stores the build artifacts generated durings the Platform.IO build. This will allow people to easily test the builds.

Generates a zip file with every `firmware.bin`. Current contents:

```
./fib64_mini__d1_mini/firmware.bin
./fastled_webserver__d1_mini/firmware.bin
./chamaeleon64__d1_mini/firmware.bin
./fib32__d1_mini/firmware.bin
./fib64_full__d1_mini/firmware.bin
./esp_thing__d1_mini/firmware.bin
./fib256__d1_mini/firmware.bin
./fib512__d1_mini/firmware.bin
./kraken64__d1_mini/firmware.bin
./1628_rings__d1_mini/firmware.bin
./fib128__d1_mini/firmware.bin
```

[Example run](https://github.com/balloob/esp8266-fastled-webserver/actions/runs/1590913373)