### PR TITLE
Faster builds -- better error messaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,34 @@ jobs:
       - name: Build with Arduino-CLI
         run: bash ci/build-arduino.sh
 
-  pio-build:
+  pio-builds:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        product:
+          - fastled_webserver
+          - esp_thing
+          - kraken64
+          - chamaeleon64
+          - 1628_rings
+          - fib1024
+          - fib512
+          - fib256
+          - fib128
+          - fib64_full
+          - fib64_mini
+          - fib32
+        platform:
+          - d1_mini
+          # - mini32 # When ESP32 is supported, one-line change to enable 2x product builds
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Build with PlatformIO
+      - name: Build
+        env:
+          FIB_PRODUCT: ${{ matrix.product }}__${{ matrix.platform }}
         run: bash ci/build-platformio.sh
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,3 +46,4 @@ jobs:
           path: |
             .pio/build/*/firmware.bin
             .pio/build/*/firmware.elf
+            .pio/build/*/littlefs.bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,4 +43,6 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: firmware
-          path: .pio/build/*/firmware.bin
+          path: |
+            .pio/build/*/firmware.bin
+            .pio/build/*/firmware.elf

--- a/ci/build-platformio.sh
+++ b/ci/build-platformio.sh
@@ -17,7 +17,8 @@ pio platform install "espressif8266"
 # Compile project
 if [[ ! -v FIB_PRODUCT ]]; then
     pio run
+    pio run --target buildfs
 else
     pio run --environment ${FIB_PRODUCT}
+    pio run --target buildfs --environment ${FIB_PRODUCT}
 fi
-

--- a/ci/build-platformio.sh
+++ b/ci/build-platformio.sh
@@ -15,4 +15,9 @@ python3 get-platformio.py
 pio platform install "espressif8266"
 
 # Compile project
-pio run
+if [[ ! -v FIB_PRODUCT ]]; then
+    pio run
+else
+    pio run --environment ${FIB_PRODUCT}
+fi
+


### PR DESCRIPTION
This spins up a separate build for each platform.
CI builds complete in ~90 seconds (vs. >630 seconds).
Also prepares for enabling ESP32 builds (when that's worked on).